### PR TITLE
chore(docs-watch): sync monitored rate-limit hash

### DIFF
--- a/docs/github-documentation/watch-list.json
+++ b/docs/github-documentation/watch-list.json
@@ -4,7 +4,7 @@
       "file": "docs/github-documentation/rate-limit.md",
       "markdown_link": "https://docs.github.com/en/rest/rate-limit/rate-limit.md",
       "redirect_link": "https://docs.github.com/api/article/body?pathname=/en/rest/rate-limit/rate-limit",
-      "content_sha256": "df3b97d2a4084a312b8b20e7b373217e6266b1027c1910c15d93c752e1fff883"
+      "content_sha256": "42392ef775d83c7ae79cbd3d49e7881e16728c23b003be137dc57e7c6993f79a"
     },
     {
       "file": "docs/github-documentation/rate-limits-for-the-rest-api.md",


### PR DESCRIPTION
## Summary
- sync the monitored `rate-limit.md` hash after the July 9, 2026 local docs-watch review

## Docs-watch review
- Local private-state review detected 1 changed monitored doc: `docs/github-documentation/rate-limit.md`
- The upstream diff only collapsed repeated `Rate Limit` field listings into cross-references
- Severity: low
- Project changes required: yes (metadata only)
- Runtime code changes required: no

## Validation
- `DOC_WATCH_STATE_DIR="$HOME/.local/state/github-api-usage-monitor/docs-watch" DOC_WATCH_REMOTE_DIR="$DOC_WATCH_STATE_DIR/remote" DOC_WATCH_REVIEW_DIR="$DOC_WATCH_STATE_DIR/review" npm run docs-watch:review`
- `DOC_WATCH_STATE_DIR="$HOME/.local/state/github-api-usage-monitor/docs-watch" DOC_WATCH_REMOTE_DIR="$DOC_WATCH_STATE_DIR/remote" DOC_WATCH_REVIEW_DIR="$DOC_WATCH_STATE_DIR/review" npm run sync:github-docs-state`
- `DOC_WATCH_STATE_DIR="$HOME/.local/state/github-api-usage-monitor/docs-watch" DOC_WATCH_REMOTE_DIR="$DOC_WATCH_STATE_DIR/remote" DOC_WATCH_REVIEW_DIR="$DOC_WATCH_STATE_DIR/review" npm run docs-watch:local`

## Notes
- No upstream GitHub docs bodies were committed
- Post-update local docs check is clean (`changed: false`)
