### PR TITLE
chore(docs-watch): sync monitored GitHub doc hashes

### DIFF
--- a/docs/github-documentation/watch-list.json
+++ b/docs/github-documentation/watch-list.json
@@ -4,13 +4,13 @@
       "file": "docs/github-documentation/rate-limit.md",
       "markdown_link": "https://docs.github.com/en/rest/rate-limit/rate-limit.md",
       "redirect_link": "https://docs.github.com/api/article/body?pathname=/en/rest/rate-limit/rate-limit",
-      "content_sha256": "42392ef775d83c7ae79cbd3d49e7881e16728c23b003be137dc57e7c6993f79a"
+      "content_sha256": "c5e59f79d3e7ebfee88cf31cd6e289f63767c97b727f7823fe5629807fff36d3"
     },
     {
       "file": "docs/github-documentation/rate-limits-for-the-rest-api.md",
       "markdown_link": "https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api.md",
       "redirect_link": "https://docs.github.com/api/article/body?pathname=/en/rest/using-the-rest-api/rate-limits-for-the-rest-api",
-      "content_sha256": "2eedb1d346385ae76fab8d9114b06e546aab690b8fdee3d52e59379537a42212"
+      "content_sha256": "731e54fb854063e0d8f3b8bafda9201e63867f231d90e08e021ac637b0b566ce"
     }
   ]
 }

--- a/docs/github-documentation/watch-list.json
+++ b/docs/github-documentation/watch-list.json
@@ -4,7 +4,7 @@
       "file": "docs/github-documentation/rate-limit.md",
       "markdown_link": "https://docs.github.com/en/rest/rate-limit/rate-limit.md",
       "redirect_link": "https://docs.github.com/api/article/body?pathname=/en/rest/rate-limit/rate-limit",
-      "content_sha256": "c5e59f79d3e7ebfee88cf31cd6e289f63767c97b727f7823fe5629807fff36d3"
+      "content_sha256": "ba6148cc8ed3be062c62f4b8a233b4351c88fcd64acd5c035a3213ff14f33649"
     },
     {
       "file": "docs/github-documentation/rate-limits-for-the-rest-api.md",


### PR DESCRIPTION
## Summary
- sync the monitored GitHub documentation hashes through the July 30, 2026 local docs-watch review

## Docs-watch review
- Private-state exact review detected two stale monitored hashes
- The only textual change updates GitHub's GraphQL documentation fragment from `#rate-limit` to `#primary-rate-limit`; rate-limit semantics, API fields, and required client behavior are unchanged
- The REST rate-limits guide matched the private baseline exactly and produced no textual diff
- Severity: low
- Project changes required: metadata only
- Runtime code, tests, and user-facing documentation changes required: no

## Validation
- `npm run docs-watch:review` with stable external `DOC_WATCH_*` paths
- synchronized the reviewed private baseline and manifest
- post-sync exact check: `changed=false`, `changed_count=0`
- `git diff --check`

## Notes
- No upstream GitHub documentation bodies are stored or committed
- The PR contains only monitored hash metadata changes
