### PR TITLE
chore(deps): update CodeQL upload action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Updates `github/codeql-action/upload-sarif` from `v4.37.7` to `v4.37.9`, retaining the full commit-SHA pin.
- This supersedes the identical update proposed in Dependabot PR #150.

## Risk assessment

- This is a patch release with no declared workflow-input or action-contract breaking changes. It updates the action's default CodeQL bundle to 2.26.4.
- No major-version updates were included. `npm-check-updates` identifies TypeScript 7 and Vitest 5 as available major upgrades; both need a separate compatibility review.

## Verification

- `npm ci` — passed; 0 vulnerabilities reported.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npm run test:all` — passed (266 unit tests; 6 integration tests).
- `npm run build:all` — passed.
- Commit hooks also passed lint, formatting, unit tests, build, generated-workflow consistency, and `check-updates`.

## Follow-up

- Evaluate TypeScript 7 and Vitest 5 in a dedicated major-upgrade PR.